### PR TITLE
Fix authentication bugs, logic flaw around counters and add input validations

### DIFF
--- a/src/icp_rust_boilerplate_backend/Cargo.toml
+++ b/src/icp_rust_boilerplate_backend/Cargo.toml
@@ -14,3 +14,4 @@ ic-cdk = "0.11.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 ic-stable-structures = "0.5.6"
+validator = { version = "0.15", features = ["derive"] }


### PR DESCRIPTION
## Fixes and Improvements

1. I have noticed that previously the customers and cars Vecs shared the same ID counter. This can cause the respective getter functions to not work as intended(e.g if a customer has an ID of 1, no cars with ID of 1 will exist which will make the get_car function return an error if a user tries to fetch a car with that ID). This also means that users and APIs that will potentially interact with this canister will be required to keep track of all the IDs of cars and customers which is not ideal.
2. I have implemented input validations for the add_car and add_customer functions using the Validator crate.
3. I have noticed that anyone could perform an update or delete a car. I've modified the owner field to store the principal of the caller of the add_car function and implemented authentication checks in the respective functions to ensure that only the owner of a car can perform those actions.
4. I have noticed that the make_reservation function could be called on cars that were already booked. I have gone ahead and implemented a check to prevent that.